### PR TITLE
SFDC2BQ user agent, job labels, and SFDC metadata

### DIFF
--- a/apps/sfdc2bq/src/deployment/terraform/main.tf
+++ b/apps/sfdc2bq/src/deployment/terraform/main.tf
@@ -143,6 +143,10 @@ resource "google_cloud_run_v2_job" "default" {
           name  = "SFDC_OBJECTS"
           value = var.sfdc_objects
         }
+        env {
+          name  = "STORE_SFDC_METADATA"
+          value = tostring(var.store_sfdc_metadata)
+        }
 
         resources {
           limits = {

--- a/apps/sfdc2bq/src/deployment/terraform/variables.tf
+++ b/apps/sfdc2bq/src/deployment/terraform/variables.tf
@@ -74,6 +74,12 @@ variable "use_existing_dataset" {
   default     = false
 }
 
+variable "store_sfdc_metadata" {
+  type        = bool
+  description = "Whether to store SFDC object metadata in _sfdc_metadata table"
+  default     = true
+}
+
 variable "bq_location" {
   type        = string
   description = "The location of the BigQuery dataset"

--- a/apps/sfdc2bq/src/sfdc2bq/env_main.sh
+++ b/apps/sfdc2bq/src/sfdc2bq/env_main.sh
@@ -22,6 +22,7 @@ python3 main.py \
     --dataset "${BQ_DATASET}" \
     --location "${BQ_LOCATION}" \
     --sfdc-connection-secret "${SFDC_AUTH_SECRET}" \
-    --objects-to-replicate "${SFDC_OBJECTS}"
+    --objects-to-replicate "${SFDC_OBJECTS}" \
+    --store-sfdc-metadata "${STORE_SFDC_METADATA}"
 
 echo "✅"

--- a/apps/sfdc2bq/src/sfdc2bq/sfdc2bq/__init__.py
+++ b/apps/sfdc2bq/src/sfdc2bq/sfdc2bq/__init__.py
@@ -35,7 +35,8 @@ def sfdc2bq_replicate(
         text_encoding: str = "utf-8",
         include_non_standard_fields: typing.Union[bool,
                                                   typing.Iterable[str]] = False,
-        exclude_standard_fields: typing.Optional[typing.Iterable[str]] = None) -> None:
+        exclude_standard_fields: typing.Optional[typing.Iterable[str]] = None,
+        store_metadata: bool = False) -> None:
     """Method to extract data from Salesforce to BigQuery
 
     Args:
@@ -50,6 +51,8 @@ def sfdc2bq_replicate(
             non-standard fields, True/False or a list of names
         exclude_standard_fields (Iterable[str]): list of standard fields
             to exclude from replication
+        store_metadata (bool, optional): Whether to store SFDC object metadata.
+                                         Defaults to False.
     """
 
     SalesforceToBigquery.replicate(
@@ -61,4 +64,5 @@ def sfdc2bq_replicate(
         output_table_name=output_table_name,
         text_encoding=text_encoding,
         include_non_standard_fields=include_non_standard_fields,
-        exclude_standard_fields=exclude_standard_fields)
+        exclude_standard_fields=exclude_standard_fields,
+        store_metadata=store_metadata)

--- a/apps/sfdc2bq/src/sfdc2bq/sfdc2bq_launcher.py
+++ b/apps/sfdc2bq/src/sfdc2bq/sfdc2bq_launcher.py
@@ -36,7 +36,8 @@ def replicate_sfdc_object_to_bq(
     bq_project_id: str,
     bq_dataset_name: str,
     bq_output_table_name: typing.Optional[str] = None,
-    bq_location: str = "US"
+    bq_location: str = "US",
+    store_metadata: bool = False
 ) -> None:
     """Replicates a single SFDC object to BigQuery
 
@@ -89,6 +90,8 @@ def replicate_sfdc_object_to_bq(
         bq_dataset_name (str): Target BigQuery dataset name.
         bq_output_table_name (str, optional): Target BigQuery table name.
         bq_location (str, optional): BigQuery location. Defaults to "US".
+        store_metadata (bool, optional): Whether to store SFDC object metadata.
+                                        Defaults to False.
     """
 
     client_info = ClientInfo(user_agent=SFDC2BQ_USER_AGENT)
@@ -158,4 +161,5 @@ def replicate_sfdc_object_to_bq(
                       dataset_name=bq_dataset_name,
                       output_table_name=bq_output_table_name,
                       text_encoding="utf-8",
-                      include_non_standard_fields=True)
+                      include_non_standard_fields=True,
+                      store_metadata=store_metadata)

--- a/apps/sfdc2bq/src/sfdc2bq/sfdc2bq_launcher.py
+++ b/apps/sfdc2bq/src/sfdc2bq/sfdc2bq_launcher.py
@@ -17,6 +17,7 @@ import json
 import typing
 from urllib.parse import unquote, urlparse, parse_qs
 
+from google.api_core.client_info import ClientInfo
 from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 from google.cloud import secretmanager
@@ -25,6 +26,8 @@ from simple_salesforce import Salesforce  # type: ignore
 
 # pylint:disable=wrong-import-position
 from sfdc2bq import sfdc2bq_replicate  # type: ignore
+
+SFDC2BQ_USER_AGENT = f"sfdc2bq/1.0 (GPN:SFDC2BQ;)"
 
 
 def replicate_sfdc_object_to_bq(
@@ -88,7 +91,10 @@ def replicate_sfdc_object_to_bq(
         bq_location (str, optional): BigQuery location. Defaults to "US".
     """
 
-    bq_client = bigquery.Client(project=bq_project_id, location=bq_location)
+    client_info = ClientInfo(user_agent=SFDC2BQ_USER_AGENT)
+    bq_client = bigquery.Client(project=bq_project_id,
+                                location=bq_location,
+                                client_info=client_info)
     try:
         _ = bq_client.get_dataset(bq_dataset_name)
     except NotFound:


### PR DESCRIPTION
* Custom BigQuery user agent for sfdc2bq
* Job labels specific to sfdc2bq
* SFDC metadata in `_sfdc_metadata` table (one row per replicated object type, e.g. Account, Opportunity, etc.)